### PR TITLE
Upgraded code to build against `pipes-4.0.0`

### DIFF
--- a/pianola.cabal
+++ b/pianola.cabal
@@ -58,7 +58,7 @@ Library
         logict >= 0.5,
         errors >= 1.3,
         either >= 3.4,
-        pipes >= 3.1,
+        pipes >= 4.0,
         free >= 3.2,
         comonad >= 3.0, 
         comonad-transformers >= 3.0, 

--- a/src/Pianola/Util.hs
+++ b/src/Pianola/Util.hs
@@ -27,9 +27,9 @@ import Control.Comonad.Trans.Env
 import Control.Applicative
 import Control.Monad.Trans.Maybe
 import Control.Monad.Logic
-import Control.Proxy
 import qualified Data.Text as T
 import qualified Data.ByteString as B
+import Pipes
 
 import Pianola.Internal
 
@@ -88,11 +88,11 @@ data LogEntry = TextEntry T.Text
                 |ImageEntry Image
 
 -- pipes
-type Produ t = Producer ProxyFast t
-type Consu t = Consumer ProxyFast t
+type Produ t = Producer t
+type Consu t = Consumer t
 
 instance Monad m => Loggy (Produ LogEntry m) where
-    logentry = respond 
+    logentry = yield
 
 instance (Monad l, Loggy l) => Loggy (LogicT l) where
     logentry = lift . logentry


### PR DESCRIPTION
I was going through reverse dependencies of `pipes` to upgrade downstream libraries that used the `pipes-3.0` API.  This pull request upgrades `pianola` to build against `pipes-4.0`.

Note that `pipes-4.0` eliminated the need for the proxy transformer system so there is no longer a `p` type parameter.  That means you probably don't need to use the `Produ` and `Consu` type synonymes any longer because now you can just use `Producer` and `Consumer` directly.  However, I'll leave that up to you to decide if you want to change that or not.
